### PR TITLE
Glibc>=2.25

### DIFF
--- a/unsquashfs.c
+++ b/unsquashfs.c
@@ -33,6 +33,7 @@
 
 #include <sys/sysinfo.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <limits.h>

--- a/unsquashfs.c
+++ b/unsquashfs.c
@@ -32,7 +32,7 @@
 #include "stdarg.h"
 
 #include <sys/sysinfo.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <limits.h>

--- a/unsquashfs.c
+++ b/unsquashfs.c
@@ -32,8 +32,7 @@
 #include "stdarg.h"
 
 #include <sys/sysinfo.h>
-#include <sys/sysmacros.h>
-
+#include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <limits.h>

--- a/unsquashfs.c
+++ b/unsquashfs.c
@@ -32,8 +32,8 @@
 #include "stdarg.h"
 
 #include <sys/sysinfo.h>
-#include <sys/types.h>
 #include <sys/sysmacros.h>
+
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <limits.h>


### PR DESCRIPTION
Created a separate branch for those systems running glibc >= v2.25.
But the best solution i guess would be to make a check for which file that needs to be included, and just use that on the master branch to have compatibility with both versions of glibc.

glibc 2.25 changelog: https://sourceware.org/ml/libc-alpha/2017-02/msg00079.html